### PR TITLE
add field descriptor

### DIFF
--- a/src/ForceFieldDescriptor.js
+++ b/src/ForceFieldDescriptor.js
@@ -1,0 +1,121 @@
+const abs = Math.abs;
+
+export class ForceFieldDescriptor {
+  
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+    console.log("FORECE FIELD DESC");
+  }
+
+  isField() {
+    return abs(this.x) < 1 && abs(this.y) < 1;
+  }
+
+  isCore() {
+    return abs(this.x) < 0.5 && abs(this.y) < 0.5;
+  }
+
+  isContext() {
+    return this.isField() && !this.isCore();
+  }
+
+  isOff() {
+    return !this.isField();
+  }
+
+  isInsideAspect() {
+    return this.isField() && this.x < 0;
+  }
+
+  isOutsideAspect() {
+    return this.isField() && this.x > 0;
+  }
+
+  isAbstractAspect() {
+    return this.isField() && this.y > 0;
+  }
+
+  isConcreteAspect() {
+    return this.isField() && this.y < 0;
+  }
+
+  getCharacterQuadrant() {
+    if(this.isInsideAspect() && this.isAbstractAspect()) {
+      return 'idea';
+    }
+    if(this.isOutsideAspect() && this.isAbstractAspect()) {
+      return 'value';
+    }
+    if(this.isOutsideAspect() && this.isConcreteAspect()) {
+      return 'market';
+    }
+    if(this.isInsideAspect() && this.isConcreteAspect()) {
+      return 'resources';
+    }
+    return undefined;
+  }
+
+  getArea() {
+
+    if(!this.isField()) {
+      return undefined;
+    }
+    const map = {
+      'idea': ['uniquness', 'drivers', 'goals'],
+      'value': ['problem', 'users', 'motivations'],
+      'market': ['competitors', 'customers', 'distribution'],
+      'resources': ['solution', 'enablers', 'production'],
+    };
+    var areas = map[this.getCharacterQuadrant()];
+
+    if(this.isCore()) {
+      return areas[0];
+    }
+    if(abs(this.x) > abs(this.y)) {
+      return areas[1];
+    }
+    if(abs(this.x) <= abs(this.y)) {
+      return areas[2];
+    }
+  }
+
+  getClassNames() {
+    var d = [];
+    if(this.isField()) {
+      d.push('field');
+    }
+    if(this.isOff()) {
+      d.push('off');
+    }
+    if(this.isCore()) {
+      d.push('core');
+    }
+    if(this.isContext()) {
+      d.push('context');
+    }
+    if(this.isInsideAspect()) {
+      d.push('inside');
+    }
+    if(this.isOutsideAspect()) {
+      d.push('outside');
+    }
+    if(this.isAbstractAspect()) {
+      d.push('abstract');
+    }
+    if(this.isConcreteAspect()) {
+      d.push('concrete');
+    }
+    var quadrant = this.getCharacterQuadrant();
+    if(quadrant) {
+      d.push(quadrant);
+    }
+
+    var area = this.getArea();
+    if(area) {
+      d.push(area);
+    }
+    return d.join(' ');
+  }
+  
+}

--- a/src/components/ForceField/Canvas.jsx
+++ b/src/components/ForceField/Canvas.jsx
@@ -8,6 +8,7 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 import Radium from 'radium';
 import {Map} from 'immutable';
 import {ForceFieldCalculationSingleton, coordinateSystemTransformation} from '../../ForceFieldCalculation';
+import {ForceFieldDescriptor} from '../../ForceFieldDescriptor';
 
 export default Radium(React.createClass({
   mixins: [PureRenderMixin],
@@ -193,7 +194,13 @@ export default Radium(React.createClass({
     var pxX = event.pageX - field.offsetLeft;
     var pxY = event.pageY - field.offsetTop;
 
+    var [normalizedX, normalizedY] = this.normalizeCoordinates(pxX, pxY);
+
     console.log(pxX, pxY, this.normalizeCoordinates(pxX, pxY));
+
+    var descriptor = new ForceFieldDescriptor(normalizedX, normalizedY);
+    console.log(descriptor.getClassNames());
+
   },
 
   componentDidMount: function() {


### PR DESCRIPTION
a class to give positions / areas in the productfield a name, based on normalized coordinates.

no more confusion, when naming things. based on the productfield pdf: http://productfield.com/assets/pdf/the-productfield-v2.pdf

![image](https://cloud.githubusercontent.com/assets/25339/11803501/de5fa668-a2fb-11e5-9846-da852dc7441c.png)

![image](https://cloud.githubusercontent.com/assets/25339/11803505/eb1f0754-a2fb-11e5-9f3d-9958d33942cc.png)
