### PR TITLE
Revert "Refactor renderer"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
-  "repository": "https://github.com/preciousforever/productfield",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/preciousforever/productfield.git"
+  },
   "name": "product-field",
   "version": "0.0.1",
+  "repository": "https://github.com/preciousforever/productfield",
   "description": "App for The Product Field · productfield.com",
   "main": "states.js",
   "scripts": {
@@ -19,26 +23,22 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "babel-core": "^6.5.1",
-    "babel-eslint": "^4.1.6",
-    "babel-loader": "^6.2.2",
-    "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
-    "babel-preset-es2015": "^6.5.0",
-    "babel-preset-react": "^6.5.0",
+    "babel-core": "^5.8.25",
+    "babel-loader": "^5.3.2",
     "chai": "^3.3.0",
     "chai-immutable": "^1.3.0",
     "css-loader": "^0.23.0",
-    "eslint": "^1.10.3",
-    "eslint-plugin-babel": "^3.0.0",
-    "eslint-plugin-react": "^3.15.0",
     "jsdom": "^6.5.1",
     "mocha": "^2.3.3",
+    "style-loader": "^0.13.0",
     "raw-loader": "^0.5.1",
     "react-addons-test-utils": "^0.14.0",
-    "react-tabs": "^0.5.3",
-    "style-loader": "^0.13.0",
     "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.12.0"
+    "webpack-dev-server": "^1.12.0",
+    "babel-eslint": "^4.1.6",
+    "eslint": "^1.10.3",
+    "eslint-plugin-babel": "^3.0.0",
+    "eslint-plugin-react": "^3.15.0"
   },
   "dependencies": {
     "express": "^4.13.3",

--- a/src/ForceFieldAnatomy.jsx
+++ b/src/ForceFieldAnatomy.jsx
@@ -27,10 +27,8 @@ export default {
 
   DOTS_IN_GRID: 21,
   DOTS_PER_SIDE: 10,
-  ARROWS_PER_SIDE: 15,
   CORE_WIDTH: 5,
   CONTEXT_WIDTH: 8,
-  CONTEXT_MARKER_SIZE: 0.5,
   CENTER_RADIUS: Math.sqrt(2),
   LABELS: {
     context: [ // starting top-left, clockwise
@@ -56,9 +54,9 @@ export default {
       labels: ['motivations', 'users', 'problem'],
       coefficient: {
         x: 1,
-        y: 1,
+        y: 1
       },
-      deg: 0,
+      deg: 0
     },
     {
       name: 'market',
@@ -88,4 +86,4 @@ export default {
       deg: 270
     }
   ],
-};
+}

--- a/src/component_library.jsx
+++ b/src/component_library.jsx
@@ -1,78 +1,23 @@
-/* eslint no-magic-numbers: 0 */
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
-import {Tabs, Tab, TabList, TabPanel} from 'react-tabs';
-import {StateProxy} from './components/state_proxy';
 import {ForceArrow} from './components/Editor/Stage/Renderer/ForceArrow';
 import {Forces} from './components/Editor/Stage/Renderer/Forces';
 import {Grid} from './components/Editor/Stage/Renderer/Grid';
 import {Marker} from './components/Editor/Stage/Renderer/Marker';
-import {Lines} from './components/Editor/Stage/Renderer/Lines';
-import {Labels} from './components/Editor/Stage/Renderer/Labels';
-import {Areas} from './components/Editor/Stage/Renderer/Areas';
 import {Renderer} from './components/Editor/Stage/Renderer';
 import {Slider} from './components/Editor/Stage/Energy/Slider';
 import {Energy} from './components/Editor/Stage/Energy';
-import {Crosshatch, Dots, Stripe} from './components/Editor/Stage/Renderer/Defs/Patterns';
-import {Arrow} from './components/Editor/Stage/Renderer/Defs/Symbols';
+import {StateProxy} from './components/state_proxy';
 
 class SvgComponent extends Component {
   render() {
-    const {origin, width, height, scaleFactor} = this.props;
     return (
-      <svg
-        style={this.props.style}
-        width={width}
-        height={height}
-        viewBox={`-${origin.x / scaleFactor} -${origin.y / scaleFactor} ${width / scaleFactor} ${height / scaleFactor}`}>
+      <svg style={this.props.style}>
         {this.props.children}
       </svg>
     );
   }
 }
-
-SvgComponent.propTypes = {
-  width: PropTypes.number,
-  height: PropTypes.number,
-  scaleFactor: PropTypes.number,
-  origin: PropTypes.shape({
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired,
-  }),
-  style: PropTypes.object,
-};
-
-SvgComponent.defaultProps = {
-  width: 300,
-  height: 300,
-  scaleFactor: 1,
-  origin: {x: 0, y: 0},
-  style: {},
-};
-
-class SvgPattern extends Component {
-  render() {
-    const {style, width, height, origin, patternId} = this.props;
-    return (
-      <SvgComponent
-        style={style}
-        width={width}
-        height={height}
-        origin={origin}>
-        <defs>
-          {this.props.children}
-        </defs>
-        <rect width={width} height={height} fill={`url(#${patternId})`} />
-      </SvgComponent>
-    );
-  }
-}
-
-SvgPattern.propTypes = Object.assign({}, SvgComponent.propTypes, {
-  patternId: PropTypes.string.isRequired,
-});
-
-SvgPattern.defaultProps = Object.assign({}, SvgComponent.defaultProps);
 
 function normalizeCoordinates(x,y) {
   return [x,y];
@@ -87,201 +32,137 @@ function deNormalizeCoordinates(x,y) {
 // const gridUnit = Math.floor(maximumFieldSize / dotsInField);
 // const fieldSize = gridUnit * dotsInField
 const energies = [
-  {id: '1', x: 1, y: 1, strength: -2, isMuted: false},
-  {id: '2', x: -1, y: -1, strength: 2, isMuted: false},
+  {id: '1', x: 149, y: 149, strength: -1, isMuted: false},
+  {id: '2', x: 151, y: 151, strength: 1, isMuted: false},
 ];
 
 ReactDOM.render(
-  <Tabs style={{padding: '10px'}}>
-    <TabList>
-      <Tab>Renderer</Tab>
-      <Tab>Patterns</Tab>
-      <Tab>Energy</Tab>
-    </TabList>
-    <TabPanel title='Renderer'>
-      <h2>Forces</h2>
-      <SvgComponent
-        origin={{x: 150, y: 150}}
-        style={{padding: '10px', backgroundColor: 'lightgray', overflow: 'visible'}}>
-        {StateProxy(
-          <Forces
-            energies={energies}
-            gridUnit={0.1}
-            scaleFactor={15}
-            arrowsPerSide={10}
-            skin={{negativeArrow: '#ff0000', positiveArrow: '#00ff00'}}
-            normalizeCoordinates={normalizeCoordinates}
-          />
-        )}
-      </SvgComponent>
-      <h2>ForceArrow</h2>
-      <SvgComponent
-        width={100}
-        height={100}
-        style={{backgroundColor: 'lightgray', overflow: 'visible'}}>
-        {StateProxy(
-          <ForceArrow
-            x={50}
-            y={50}
-            x2={60}
-            y2={60}
-            deg={90}
-            triangleSize={4}
-            skin={{negativeArrow: '#ff0000', positiveArrow: '#00ff00'}}
-            normalizeCoordinates={normalizeCoordinates}
-          />
-        )}
-      </SvgComponent>
-      <h2>Grid</h2>
-      <SvgComponent
-        width={500}
-        height={500}
-        origin={{x: 250, y: 250}}
-        style={{padding: '10px', backgroundColor: 'lightgray', overflow: 'visible'}}>
-        {StateProxy(
-          <Grid
-            scaleFactor={20}
-            gridUnit={0.1}
-            dotsPerSide={10}
-            skin={{dots: '#ff0000'}}
-            normalizeCoordinates={normalizeCoordinates}
-          />
-        )}
-      </SvgComponent>
-      <h2>Marker</h2>
-      <SvgComponent
-        width={500}
-        height={500}
-        scaleFactor={1}
-        origin={{x: 250, y: 250}}
-        style={{padding: '10px', backgroundColor: 'lightgray', overflow: 'visible'}}>
-        {StateProxy(
-          <Marker
-            scaleFactor={20}
-            skin={{marker: '#ff0000'}}
-          />
-        )}
-      </SvgComponent>
-      <h2>Lines</h2>
-      <SvgComponent
-        origin={{x: 150, y: 150}}
-        style={{padding: '10px', backgroundColor: 'lightgray', overflow: 'visible'}}>
-        {StateProxy(
-          <Lines
-            scaleFactor={15}
-          />
-        )}
-      </SvgComponent>
-      <h2>Areas</h2>
-      <SvgComponent
-        origin={{x: 150, y: 150}}
-        style={{padding: '10px', backgroundColor: 'lightgray', overflow: 'visible'}}>
-        {StateProxy(
-          <Areas
-            scaleFactor={15}
-          />
-        )}
-      </SvgComponent>
-      <h2>Labels</h2>
-      <SvgComponent
-        width={400}
-        height={400}
-        origin={{x: 200, y: 200}}
-        style={{padding: '10px', backgroundColor: 'lightgray', overflow: 'visible'}}>
-        {StateProxy(
-          <Labels
-            scaleFactor={20}
-          />
-        )}
-      </SvgComponent>
-      <h2>Renderer</h2>
+  <div style={{padding: '10px'}}>
+    <h2>Forces</h2>
+    <SvgComponent style={{padding: '10px', backgroundColor: 'lightgray', overflow: 'visible'}}>
       {StateProxy(
-        <Renderer
-          width={300}
-          height={300}
-          fieldSize={250}
-          gridUnit={0.1}
-          scaleFactor={15}
+        <Forces
           energies={energies}
-          triangleSize={4}
-          minLengthForArrowsToDisplay={2}
-          skin={{
-            background: 'rgba(150,150,0,0.4)',
-            dots: '#ff0000',
-            marker: '#00ff00',
-            negativeArrow: '#ff0000',
-            positiveArrow: '#00ff00',
-          }}
+          stageWidth={300}
+          stageHeight={300}
+          fieldSize={250}
+          gridUnit={250 / 10}
+          skin={{negativeArrow: '#ff0000', positiveArrow: '#00ff00'}}
+          normalizeCoordinates={normalizeCoordinates}
         />
       )}
-    </TabPanel>
-    <TabPanel title='Patterns'>
-      <h2>Arrow</h2>
-      <SvgComponent>
-        <defs>
-          <Arrow gridUnit={15} offset={{x:0,y:0}} size={{width: 300, height: 300}} origin={{x:0, y:0}}/>
-        </defs>
-        <use xlinkHref='#arrow'/>
-      </SvgComponent>
-      <h2>Crosshatch</h2>
-      <SvgPattern patternId='Crosshatch'>
-        <Crosshatch gridUnit={15} offset={{x:0,y:0}} size={{width: 300, height: 300}} origin={{x:0, y:0}}/>
-      </SvgPattern>
-      <h2>Stripe</h2>
-      <SvgPattern patternId='Stripe'>
-        <Stripe gridUnit={15} offset={{x:0,y:0}} size={{width: 300, height: 300}} origin={{x:0, y:0}}/>
-      </SvgPattern>
-      <h2>Dots</h2>
-      <SvgPattern patternId='dots'>
-        {StateProxy(
-          <Dots gridUnit={15} offset={{x:0,y:0}} size={{width: 300, height: 300}} origin={{x:0, y:0}}/>
-        )}
-      </SvgPattern>
-    </TabPanel>
-    <TabPanel title='Energy'>
-      <h2>Slider</h2>
+    </SvgComponent>
+    <h2>ForceArrow</h2>
+    <SvgComponent style={{width: '100px', height: '100px', backgroundColor: 'lightgray', overflow: 'visible'}}>
       {StateProxy(
-        <Slider value={3} isPresentation={false} onChange={(value) => console.log(`Slider.onChange(${value})`)} />
-      )}
-      <h2>Energy</h2>
-      {StateProxy(
-        <Energy
-          id={1}
-          x={0}
-          y={0}
-          isMuted={true}
-          strength={2}
-          isPresentation={false}
+        <ForceArrow
+          x={50}
+          y={50}
+          x2={60}
+          y2={60}
+          deg={90}
+          triangleSize={4}
+          skin={{negativeArrow: '#ff0000', positiveArrow: '#00ff00'}}
           normalizeCoordinates={normalizeCoordinates}
-          deNormalizeCoordinates={deNormalizeCoordinates}
-          onEdit={(e) => console.log(`Energy.onEdit()`)} />
+        />
       )}
+    </SvgComponent>
+    <h2>Grid</h2>
+    <SvgComponent style={{padding: '10px', backgroundColor: 'lightgray', overflow: 'visible'}}>
       {StateProxy(
-        <Energy
-          id={2}
-          x={33}
-          y={44}
-          isMuted={false}
-          isEditing={true}
-          strength={2}
-          isPresentation={false}
+        <Grid
+          stageWidth={300}
+          stageHeight={300}
+          fieldSize={250}
+          gridUnit={250 / 10}
+          skin={{dots: '#ff0000'}}
           normalizeCoordinates={normalizeCoordinates}
-          deNormalizeCoordinates={deNormalizeCoordinates}
-          onEdit={(e) => console.log(`Energy.onEdit()`)} />
+        />
       )}
+    </SvgComponent>
+    <h2>Marker</h2>
+    <div style={{width: 'fit-content', height: 'fit-content', padding: '10px', backgroundColor: 'lightgray', overflow: 'visible'}}>
       {StateProxy(
-        <Energy
-          id={3}
-          x={77}
-          y={80}
-          isMuted={false}
-          strength={-3}
-          isPresentation={false}
-          normalizeCoordinates={normalizeCoordinates}
-          deNormalizeCoordinates={deNormalizeCoordinates}
-          onEdit={(e) => console.log(`Energy.onEdit()`)} />
+        <Marker
+          style={{overflow: 'visible'}}
+          stageWidth={300}
+          stageHeight={300}
+          fieldSize={250}
+          gridUnit={250 / 10}
+          skin={{marker: '#ff0000'}}
+        />
       )}
-    </TabPanel>
-  </Tabs>,
+    </div>
+    <h2>Renderer</h2>
+    {StateProxy(
+      <Renderer
+        width={300}
+        height={300}
+        fieldSize={250}
+        gridUnit={250/10}
+        triangleSize={4}
+        minLengthForArrowsToDisplay={2}
+        normalizeCoordinates={normalizeCoordinates}
+        skin={{
+          background: 'rgba(150,150,0,0.4)',
+          dots: '#ff0000',
+          marker: '#00ff00',
+          negativeArrow: '#ff0000',
+          positiveArrow: '#00ff00'
+        }}
+      />
+    )}
+    <h2>Slider</h2>
+    {StateProxy(
+      <Slider value={3} isPresentation={false} onChange={(value) => console.log(`Slider.onChange(${value})`)} />
+    )}
+    <h2>Energy</h2>
+    {StateProxy(
+      <Energy
+        id={1}
+        x={0}
+        y={0}
+        isMuted={true}
+        strength={2}
+        isPresentation={false}
+        normalizeCoordinates={normalizeCoordinates}
+        deNormalizeCoordinates={deNormalizeCoordinates}
+        onEdit={(e) => console.log(`Energy.onEdit()`)}
+        onMute={() => console.log(`Energy.onEdit()`)}
+        onUnmute={() => console.log(`Energy.onEdit()`)}
+        setStrength={(strength) => console.log(`Energy.setStrength(${strength})`)} />
+    )}
+    {StateProxy(
+      <Energy
+        id={2}
+        x={33}
+        y={44}
+        isMuted={false}
+        isEditing={true}
+        strength={2}
+        isPresentation={false}
+        normalizeCoordinates={normalizeCoordinates}
+        deNormalizeCoordinates={deNormalizeCoordinates}
+        onEdit={(e) => console.log(`Energy.onEdit()`)}
+        onMute={() => console.log(`Energy.onEdit()`)}
+        onUnmute={() => console.log(`Energy.onEdit()`)}
+        setStrength={(strength) => console.log(`Energy.setStrength(${strength})`)} />
+    )}
+    {StateProxy(
+      <Energy
+        id={3}
+        x={77}
+        y={80}
+        isMuted={false}
+        strength={-3}
+        isPresentation={false}
+        normalizeCoordinates={normalizeCoordinates}
+        deNormalizeCoordinates={deNormalizeCoordinates}
+        onEdit={(e) => console.log(`Energy.onEdit()`)}
+        onMute={() => console.log(`Energy.onEdit()`)}
+        onUnmute={() => console.log(`Energy.onEdit()`)}
+        setStrength={(strength) => console.log(`Energy.setStrength(${strength})`)} />
+    )}
+  </div>,
   document.getElementById('component-library')
 );

--- a/src/components/Editor/Stage.jsx
+++ b/src/components/Editor/Stage.jsx
@@ -10,28 +10,26 @@ import energyStyles from './Stage/Energy/energy.css';
 const FORCE_ARROW_HEAD_SIZE = 4;
 const MIN_FORCE_ARROW_LENGTH = 2;
 const DOTS_IN_FIELD = 20;
-const FIELD_PADDING = 50;
-const GRID_UNIT = 0.1;
 
 export class Stage extends Component {
 
   getProperties() {
-    const maximumFieldSize = Math.floor(Math.min(this.props.width, this.props.height)) - FIELD_PADDING;
-    const scaleFactor = Math.floor(maximumFieldSize / DOTS_IN_FIELD);
-    const fieldSize = scaleFactor * DOTS_IN_FIELD;
+    const maximumFieldSize = Math.floor(Math.min(this.props.width, this.props.height)) - 50;
+    const gridUnit = Math.floor(maximumFieldSize / DOTS_IN_FIELD);
+    const fieldSize = gridUnit * DOTS_IN_FIELD;
 
-    const lightSkin = {
+    const lightSkin =  {
                      dots:   "#304FFE",
                      marker: "#304FFE",
-                     lines: "#000000",
+                     arrows: "#F2F2F2",
                      positiveArrow: "#008000",
                      negativeArrow: "#800000",
                      background: '#FFFFFF',
                    };
-    const darkSkin = {
+    const darkSkin =  {
                      dots:   "#FFFFFF",
                      marker: "#FFFFFF",
-                     lines: "#F2F2F2",
+                     arrows: "#F2F2F2",
                      positiveArrow: "#008000",
                      negativeArrow: "#800000",
                      background: '#000000',
@@ -39,21 +37,20 @@ export class Stage extends Component {
 
     return {
       fieldSize: fieldSize,
-      gridUnit: GRID_UNIT,
-      scaleFactor: scaleFactor,
+      gridUnit: gridUnit,
       triangleSize: FORCE_ARROW_HEAD_SIZE,
       minLengthForArrowsToDisplay: MIN_FORCE_ARROW_LENGTH,
       width:  this.props.width,
       height: this.props.height,
       skin: this.props.isPresentationModeEnabled ? darkSkin : lightSkin,
-    };
+    }
   }
 
   deNormalizeOneCoordinate(val, isY) {
-    const properties = this.getProperties();
+    var properties = this.getProperties();
 
-    const deNormalizedVal = (val * properties.fieldSize) / 2;
-    let deTranslatedVal = deNormalizedVal;
+    var deNormalizedVal = (val * properties.fieldSize) / 2;
+    var deTranslatedVal = deNormalizedVal;
 
     if(isY) {
       deTranslatedVal = deNormalizedVal - properties.height / 2;
@@ -70,13 +67,13 @@ export class Stage extends Component {
   }
 
   normalizeCoordinates(x, y) {
-    const properties = this.getProperties();
+    var properties = this.getProperties();
 
-    const translatedX = (x - properties.width / 2);
-    const translatedY = (y - properties.height / 2);
+    var translatedX = (x - properties.width / 2);
+    var translatedY = (y - properties.height / 2);
 
-    const normalizedX = (2 * translatedX) / properties.fieldSize;
-    const normalizedY = -(2 * translatedY) / properties.fieldSize;
+    var normalizedX = (2 * translatedX) / properties.fieldSize;
+    var normalizedY = -(2 * translatedY) / properties.fieldSize;
 
     return [normalizedX, normalizedY];
   }
@@ -87,7 +84,7 @@ export class Stage extends Component {
       position: 'absolute',
       left: pixelatedX,
       top: pixelatedY,
-    };
+    }
   }
 
   energyEditorPositioningStyles(x, y) {
@@ -118,8 +115,8 @@ export class Stage extends Component {
 
     const field = node.offsetParent;
 
-    let newX = clientX - field.offsetLeft;
-    let newY = clientY - field.offsetTop;
+    var newX = clientX - field.offsetLeft;
+    var newY = clientY - field.offsetTop;
 
     if (newX <= offsetX) {
       newX = offsetX;
@@ -142,10 +139,10 @@ export class Stage extends Component {
   handleDoubleClick(event) {
     event.preventDefault();
     const stage = event.currentTarget;
-    const pXstage = event.pageX - stage.offsetLeft;
-    const pYstage = event.pageY - stage.offsetTop;
+    var pXstage = event.pageX - stage.offsetLeft;
+    var pYstage = event.pageY - stage.offsetTop;
 
-    const [normalizedX, normalizedY] = this.normalizeCoordinates(pXstage, pYstage);
+    var [normalizedX, normalizedY] = this.normalizeCoordinates(pXstage, pYstage);
 
     this.props.onEnergyAdd({id: uuid.v1(), x: normalizedX, y: normalizedY, strength: 1, isMuted: false});
   }
@@ -171,11 +168,12 @@ export class Stage extends Component {
   render() {
 
     const rendererProps = Object.assign(this.getProperties(), {
+      normalizeCoordinates: this.normalizeCoordinates.bind(this),
       energies: this.props.energies.filter((energy) => !energy.isMuted).map((energy) => ({
         x: energy.x, y: energy.y, strength: energy.strength,
       })),
       isPresentationModeEnabled: this.props.isPresentationModeEnabled,
-    });
+    })
 
     let className = 'ForceFieldStage';
     if (this.props.isEnergyMoving) {

--- a/src/components/Editor/Stage/Renderer/Areas.jsx
+++ b/src/components/Editor/Stage/Renderer/Areas.jsx
@@ -1,103 +1,75 @@
-import React, {Component, PropTypes} from 'react';
-import Vector from 'victor';
+import React, {Component} from 'react';
+import ForceFieldDescriptor from '../../../../ForceFieldDescriptor';
 import ForceFieldAnatomy from '../../../../ForceFieldAnatomy';
+import PropTypes from '../../../../PropTypes';
 
-function convertPointsToScaledSvgPath(points, scaleFactor) {
-  return points.map((point) => {
-    point.multiplyScalarX(scaleFactor).multiplyScalarY(-scaleFactor);
-    return `${point.x},${point.y}`;
-  }).join(' ');
+function convertPointsToScaledSvgPath(points, gridUnit) {
+  return points.map(
+      (point) => {
+        return Array(point[0] * gridUnit, -point[1] * gridUnit);
+      }
+    )
+    .reduce(
+      (a, b) => {
+        return a.concat(b);
+      }
+    , [])
+    .join(',');
 }
 
 export class Areas extends Component {
 
   render() {
-    const {
-      scaleFactor,
-      coreWidth, contextWidth, centerCircleRadius, contextMarkerSize,
-    } = this.props;
+    const {origin, gridUnit} = this.props;
 
-    const groups = [];
+    let groups = [];
 
-    const side = coreWidth * scaleFactor;
+    let w = 5;
+    let h = 5;
 
-    groups.push(
-      <g key={'core'} className={'Areas-core'}>
-        <rect className={'Areas-core Areas-problem'}
-          x={0} y={-side} width={side} height={side} />
-        <rect className={'Areas-core Areas-competition'}
-          x={0} y={0} width={side} height={side} />
-        <rect className={'Areas-core Areas-solution'}
-          x={-side} y={0} width={side} height={side} />
-        <rect className={'Areas-core Areas-uniqueness'}
-          x={-side} y={-side} width={side} height={side} />
-      </g>
-    );
+     groups.push(
+        <g key={'core'} className={'Areas-core'}>
+          <rect className={'Areas-core Areas-problem'} x={0} y={-h * gridUnit} width={w * gridUnit} height={w * gridUnit} />
+          <rect className={'Areas-core Areas-competition'} x={0} y={0} width={w * gridUnit} height={w * gridUnit} />
+          <rect className={'Areas-core Areas-solution'} x={-w * gridUnit} y={0} width={w * gridUnit} height={w * gridUnit} />
+          <rect className={'Areas-core Areas-uniqueness'} x={-w * gridUnit} y={-h * gridUnit} width={w * gridUnit} height={w * gridUnit} />
+        </g>
+      );
 
-    const gridContextPoints1 = convertPointsToScaledSvgPath(
-      [
-        new Vector(0, coreWidth),
-        new Vector(0, (contextWidth + contextMarkerSize)),
-        new Vector(contextWidth, (contextWidth + contextMarkerSize)),
-        new Vector(contextWidth, contextWidth),
-        new Vector(coreWidth, coreWidth),
-      ],
-      scaleFactor,
-    );
-    const gridContextPoints2 = convertPointsToScaledSvgPath(
-      [
-        new Vector(coreWidth, coreWidth),
-        new Vector(contextWidth, contextWidth),
-        new Vector((contextWidth + contextMarkerSize), contextWidth),
-        new Vector((contextWidth + contextMarkerSize), 0),
-        new Vector(coreWidth, 0),
-      ],
-      scaleFactor,
-    );
+    const gridContextPoints1 = convertPointsToScaledSvgPath([[0,5], [0,8.5], [8,8.5], [8,8], [5,5]], gridUnit);
+    const gridContextPoints2 = convertPointsToScaledSvgPath([[5,5], [8,8], [8.5,8], [8.5,0], [5,0]], gridUnit);
 
-    groups.push(ForceFieldAnatomy.QUADRANTS.map((quadrant) => {
+    ForceFieldAnatomy.QUADRANTS.forEach((quadrant) => {
+
       const deg = quadrant.deg;
       const transform = `rotate(${deg})`;
 
+      const w = 5 * quadrant.coefficient.x;
+      const h = 5 * quadrant.coefficient.y;
+
       let labelIndex1 = 0;
       let labelIndex2 = 1;
-      if (deg === 90 || deg === 270) {
+      if(deg === 90 || deg === 270) {
         labelIndex1 = 1;
         labelIndex2 = 0;
       }
 
-      return (
+      groups.push(
         <g key={`${deg}'-1'`} transform={transform}>
-          <polygon className={`Areas-context Areas-${quadrant.labels[labelIndex1]}`}
-            points={gridContextPoints1} />
-          <polygon className={`Areas-context Areas-${quadrant.labels[labelIndex2]}`}
-            points={gridContextPoints2} />
+          <polygon className={`Areas-context Areas-${quadrant.labels[labelIndex1]}`} points={gridContextPoints1} />
+          <polygon className={`Areas-context Areas-${quadrant.labels[labelIndex2]}`} points={gridContextPoints2} />
         </g>
       );
 
-    }));
+    });
 
-    return (
-      <g id="Areas" className="Areas" fill='none'>
-        {groups}
-      </g>
-    );
+    const transform = `translate(${origin.x},${origin.y})`;
+    return <g id="Areas" className="Areas" fill='none' transform={transform}>{groups}</g>;
   }
 
 }
 
 Areas.propTypes = {
-  scaleFactor: PropTypes.number,
-  contextWidth: PropTypes.number,
-  coreWidth: PropTypes.number,
-  centerCircleRadius: PropTypes.number,
-  contextMarkerSize: PropTypes.number,
-};
-
-Areas.defaultProps = {
-  scaleFactor: 1,
-  contextWidth: 8,
-  coreWidth: 5,
-  centerCircleRadius: Math.sqrt(2),
-  contextMarkerSize: 0.5,
+  gridUnit: PropTypes.number.isRequired,
+  origin: PropTypes.point.isRequired,
 };

--- a/src/components/Editor/Stage/Renderer/Defs/DefsComponent.jsx
+++ b/src/components/Editor/Stage/Renderer/Defs/DefsComponent.jsx
@@ -4,20 +4,13 @@ import PropTypes from 'PropTypes';
 export default class DefsComponent extends Component {
 
   render() {
-    const {gridUnit, origin, size} = this.props;
-    const offsetX = Math.floor(size.width / 2) % gridUnit;
-    const offsetY = Math.floor(size.height / 2) % gridUnit;
-    return this.renderDef(
-      gridUnit,
-      {x: offsetX, y: offsetY},
-      origin,
-      size,
-    );
+    return this.renderDef(this.props.gridUnit, this.props.offset, this.props.origin, this.props.size);
   }
 }
 
 DefsComponent.propTypes = {
   gridUnit: PropTypes.number.isRequired,
+  offset: PropTypes.point.isRequired,
   origin: PropTypes.point.isRequired,
   size: PropTypes.size.isRequired,
 };

--- a/src/components/Editor/Stage/Renderer/Defs/Masks.jsx
+++ b/src/components/Editor/Stage/Renderer/Defs/Masks.jsx
@@ -9,10 +9,7 @@ export class Circle extends DefsComponent {
     /*eslint no-multi-spaces:0*/
     const radius = Anatomy.CENTER_RADIUS;
     return  <mask maskUnits="userSpaceOnUse" id="circle">
-              <rect
-                width={size.width}
-                height={size.height}
-                fill="#FFFFFF" />
+              <rect width={size.width} height={size.height} fill="#FFFFFF" />
               <circle cx={origin.x} cy={origin.y} r={radius * GU} fill="#000000"></circle>
             </mask>;
   }

--- a/src/components/Editor/Stage/Renderer/Defs/Patterns.jsx
+++ b/src/components/Editor/Stage/Renderer/Defs/Patterns.jsx
@@ -4,48 +4,41 @@ import DefsComponent from './DefsComponent';
 
 export class Crosshatch extends DefsComponent {
 
-  renderDef(_GU, _offset, _origin, _size) {
-    return (
-      <pattern key="defs-crosshatch" id="Crosshatch"
-        width="8" height="8"
-        patternUnits="userSpaceOnUse">
-        <path className="Pattern-crosshatch" d='M0 0L8 8ZM8 0L0 8Z' stroke='#000000' strokeWidth='0.5' />
-      </pattern>
-      );
+  renderDef(GU, offset) {
+    /*eslint no-multi-spaces:0*/
+    return  <pattern key="defs-crosshatch" id="Crosshatch" 
+              width="8" height="8"
+              patternUnits="userSpaceOnUse">
+                <path className="Pattern-crosshatch" d='M0 0L8 8ZM8 0L0 8Z' stroke='#000000' strokeWidth='0.5' />
+            </pattern>;
   }
 
 }
 
 export class Stripe extends DefsComponent {
 
-  renderDef(_GU, _offset, _origin, _size) {
-    return (
-      <pattern key="defs-stripe" id="Stripe"
-        width="10" height="10"
-        patternUnits="userSpaceOnUse">
-        <path d='M-1,1 l2,-2M0,10 l10,-10M9,11 l2,-2'
-          stroke='#000000' strokeWidth='0.5'/>
-      </pattern>
-      );
+  renderDef(GU, offset) {
+    /*eslint no-multi-spaces:0*/
+    return  <pattern key="defs-stripe" id="Stripe" 
+              width="10" height="10"
+              patternUnits="userSpaceOnUse">
+               <path d='M-1,1 l2,-2M0,10 l10,-10M9,11 l2,-2'
+                 stroke='#000000' strokeWidth='0.5'/>
+            </pattern>;
   }
 
 }
 
 export class Dots extends DefsComponent {
 
-  renderDef(GU, _offset, _origin, _size) {
+  renderDef(GU, offset) {
+    /*eslint no-multi-spaces:0*/
     const radius = 1;
-    const patternWidth = 1;
-    const dotCenter = 0.5;
-    return (
-      <pattern key="defs-dots" id="dots"
-        width={patternWidth * GU} height={patternWidth * GU}
-        patternUnits="userSpaceOnUse">
-        <circle className="off"
-          cx={dotCenter * GU} cy={dotCenter * GU} r={radius}
-          fill="#000000" stroke="none"/>
-      </pattern>
-    );
+    return  <pattern key="defs-dots" id="dots"
+              x={offset.x} y={offset.y} width={GU} height={GU}
+              patternUnits="userSpaceOnUse">
+                <circle className="off" cx={GU / 2} cy={GU / 2} r={radius} fill="#000000" stroke="none"></circle>
+            </pattern>;
   }
 
 }

--- a/src/components/Editor/Stage/Renderer/Defs/Symbols.jsx
+++ b/src/components/Editor/Stage/Renderer/Defs/Symbols.jsx
@@ -5,12 +5,12 @@ import Anatomy from 'ForceFieldAnatomy';
 
 export class Arrow extends DefsComponent {
 
-  renderDef(_GU, _offset, _origin, _size) {
-    return (
-      <g id="arrow">
-        <path fill="#444444" d="M4 13h2l5-5-5-5h-2l5 5z"></path>
-      </g>
-    );
+  renderDef(GU, offset, origin, size) {
+    /*eslint no-multi-spaces:0*/
+    const radius = 2;
+    return  <g id="arrow">
+              <path fill="#444444" d="M4 13h2l5-5-5-5h-2l5 5z"></path>
+            </g>;
   }
 
 }

--- a/src/components/Editor/Stage/Renderer/Forces.jsx
+++ b/src/components/Editor/Stage/Renderer/Forces.jsx
@@ -1,6 +1,5 @@
 import React, {Component, PropTypes} from 'react';
 import Vector from 'victor';
-import ForceFieldAnatomy from '../../../../ForceFieldAnatomy';
 import {ForceFieldCalculator} from './ForceFieldCalculator';
 import {ForceArrow} from './ForceArrow';
 
@@ -9,50 +8,38 @@ const ARROW_GRID_CORRECTION_FACTOR = 0.8;
 export class Forces extends Component {
 
   render() {
-    const {
-      gridUnit, scaleFactor,
-      minArrowLength, arrowTriangleSize, arrowsPerSide,
-    } = this.props;
+    const {stageWidth, stageHeight, fieldSize, gridUnit, minArrowLength, arrowTriangleSize} = this.props;
+    const offsetX = Math.floor(stageWidth - fieldSize) / 2 % gridUnit;
+    const offsetY = Math.floor(stageHeight / 2 - fieldSize / 2) % gridUnit
 
     const forceCalculator = new ForceFieldCalculator(this.props.energies);
 
-    const arrows = ForceFieldAnatomy.QUADRANTS.map((quadrant) => {
-      const arrows = [];
-      for (let ix = 0; ix <= arrowsPerSide; ix++) {
-        for (let iy = 0; iy <= arrowsPerSide; iy++) {
+    let arrows = []
+    for (let x = offsetX; x < stageWidth; x += gridUnit) {
+      for (let y = offsetY; y < stageHeight; y += gridUnit) {
+        const [normalizedX, normalizedY] = this.props.normalizeCoordinates(x, y);
+        const result = forceCalculator.forceVectorAtPoint(normalizedX, normalizedY);
+        const arrowLength = result.length() * gridUnit * ARROW_GRID_CORRECTION_FACTOR;
 
-          const x = quadrant.coefficient.x * ix;
-          const y = quadrant.coefficient.y * iy;
-
-          const result = forceCalculator.forceVectorAtPoint(x * gridUnit, y * gridUnit);
-          const arrowLength = result.length() * scaleFactor * ARROW_GRID_CORRECTION_FACTOR;
-
-          if (arrowLength < minArrowLength) {
-            continue;
-          }
-          const scaledX = x * scaleFactor;
-          const scaledY = -y * scaleFactor;
-
-          arrows.push(
-            <ForceArrow key={`${x},${y}`}
-              deg={result.clone().invert().verticalAngleDeg()}
-              x={scaledX}
-              y={scaledY}
-              x2={scaledX}
-              y2={scaledY + arrowLength}
-              triangleSize={arrowTriangleSize}
-              skin={this.props.skin} />
-            );
-
+        if (arrowLength < minArrowLength) {
+          continue;
         }
+
+        const props = {
+          deg: result.clone().invert().verticalAngleDeg(),
+          x: x,
+          x2: x,
+          y: y,
+          y2: y + arrowLength,
+          triangleSize: arrowTriangleSize,
+        }
+
+        arrows.push(<ForceArrow key={`${x},${y}`} {...props} skin={this.props.skin} />)
       }
-      return arrows;
-    });
+    }
 
     return (
-      <g id="Forces" className="Forces">
-        {arrows}
-      </g>
+      <g>{arrows}</g>
     );
   }
 }
@@ -63,22 +50,21 @@ Forces.propTypes = {
     y: PropTypes.number.isRequired,
     strength: PropTypes.number.isRequired,
   })),
-  scaleFactor: PropTypes.number,
-  gridUnit: PropTypes.number,
+  stageWidth: PropTypes.number.isRequired,
+  stageHeight: PropTypes.number.isRequired,
+  fieldSize: PropTypes.number.isRequired,
+  gridUnit: PropTypes.number.isRequired,
   arrowTriangleSize: PropTypes.number,
   minArrowLength: PropTypes.number,
-  arrowsPerSide: PropTypes.number,
   skin: PropTypes.shape({
     negativeArrow: PropTypes.string.isRequired,
     positiveArrow: PropTypes.string.isRequired,
   }).isRequired,
+  normalizeCoordinates: PropTypes.func.isRequired,
 };
 
 Forces.defaultProps = {
   energies: [],
-  scaleFactor: 1,
-  gridUnit: 1,
   arrowTriangleSize: 4,
-  minArrowLength: 1,
-  arrowsPerSide: 10,
+  minArrowLength: 0,
 };

--- a/src/components/Editor/Stage/Renderer/Grid.jsx
+++ b/src/components/Editor/Stage/Renderer/Grid.jsx
@@ -13,13 +13,14 @@ function hasIntersection(a, b) {
 export class Grid extends Component {
 
   render() {
-    const {scaleFactor, gridUnit, dotsPerSide, skin: {dots}} = this.props;
+    const {origin, gridUnit, skin: {dots}} = this.props;
     const dotHighlights = new Set(this.props.dots);
 
-    const circles = ForceFieldAnatomy.QUADRANTS.map((quadrant) => {
-      const circles = [];
-      for (let ix = 0; ix <= dotsPerSide; ix++) {
-        for (let iy = 0; iy <= dotsPerSide; iy++) {
+    let circles = []
+
+    ForceFieldAnatomy.QUADRANTS.forEach(function(quadrant, index) {
+      for(let ix = 0; ix <= ForceFieldAnatomy.DOTS_PER_SIDE; ix++) {
+        for(let iy = 0; iy <= ForceFieldAnatomy.DOTS_PER_SIDE; iy++) {
 
           if (ix + iy === 0) {
             continue;
@@ -27,46 +28,35 @@ export class Grid extends Component {
 
           const x = quadrant.coefficient.x * ix;
           const y = quadrant.coefficient.y * iy;
-          const forceFieldDescriptor = new ForceFieldDescriptor(x * gridUnit, y * gridUnit);
+          const TEN = 10;
+          const forceFieldDescriptor = new ForceFieldDescriptor(x / TEN, y / TEN);
 
-          if (forceFieldDescriptor.isCenter()) {
+          if(forceFieldDescriptor.isCenter()) {
             continue;
           }
           let radius = DEFAULT_CIRCLE_RADIUS;
           const classNames = forceFieldDescriptor.getClassNames();
           const names = new Set(forceFieldDescriptor.getNames());
 
-          if (hasIntersection(names, dotHighlights)) {
+          if(hasIntersection(names, dotHighlights)) {
             radius = INTERSECTION_CIRCLE_RADIUS;
           }
 
-          const scaledX = x * scaleFactor;
-          const scaledY = y * scaleFactor;
-
-          circles.push(
-            <circle key={`${quadrant.deg}:${x},${y}`} className={classNames}
-              cx={scaledX} cy={-scaledY}
-              r={radius}
-              fill={dots} />
-            );
+          circles.push(<circle key={`${quadrant.deg}:${x},${y}`} className={classNames} cx={x * gridUnit} cy={-y * gridUnit} r={radius} stroke={dots} />);
 
         }
       }
-      return circles;
+
     });
 
-    return (
-      <g id="Grid" className="Grid">
-        {circles}
-      </g>
-    );
+    let transform = 'translate(' + origin.x + ',' + origin.y + ')';
+    return <g id="Grid" className="Grid" transform={transform}>{circles}</g>;
   }
 }
 
 Grid.propTypes = {
-  scaleFactor: PropTypes.number,
-  gridUnit: PropTypes.number,
-  dotsPerSide: PropTypes.number,
+  origin: PropTypes.point.isRequired,
+  gridUnit: PropTypes.number.isRequired,
   skin: PropTypes.shape({
     dots: PropTypes.string.isRequired,
   }).isRequired,
@@ -74,8 +64,5 @@ Grid.propTypes = {
 };
 
 Grid.defaultProps = {
-  scaleFactor: 1,
-  gridUnit: 1,
-  dotsPerSide: 5,
   dots: [],
 };

--- a/src/components/Editor/Stage/Renderer/Labels.jsx
+++ b/src/components/Editor/Stage/Renderer/Labels.jsx
@@ -1,110 +1,57 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import uuid from 'node-uuid';
+import ForceFieldDescriptor from '../../../../ForceFieldDescriptor';
 import ForceFieldAnatomy from '../../../../ForceFieldAnatomy';
+import PropTypes from '../../../../PropTypes';
 
 const LABEL_HEIGHT = 18;
-const FONT_SIZE_CORRECTION = 2;
-const FONT_SIZE = LABEL_HEIGHT - FONT_SIZE_CORRECTION;
-const CHARACTER_LABEL_POSITION = 8;
-const CONTEXT_LABEL_POSITION = 5;
-const CONTEXT_LABEL_OFFSET = 0.5;
-const CORE_LABEL_POSITION = 2.5;
 
 export class Labels extends Component {
 
   render() {
-    const {scaleFactor} = this.props;
+    const {origin, gridUnit, skin: {dots}} = this.props;
 
-    const labels = [];
+    let labels = [];
 
-    ForceFieldAnatomy.QUADRANTS.forEach((quadrant) => {
-      const leftAligned = quadrant.coefficient.x > 0 ? 'start' : 'end';
-      const rightAligned = quadrant.coefficient.x < 0 ? 'start' : 'end';
+    ForceFieldAnatomy.QUADRANTS.forEach(function(quadrant) {
 
-      let x = CHARACTER_LABEL_POSITION * quadrant.coefficient.x * scaleFactor;
-      let y = - CHARACTER_LABEL_POSITION * quadrant.coefficient.y * scaleFactor;
-      const paddingX = quadrant.coefficient.x > 0 ? LABEL_HEIGHT / 2 : - LABEL_HEIGHT / 2;
-      let paddingY = quadrant.coefficient.y > 0 ? - LABEL_HEIGHT / 2 : LABEL_HEIGHT;
+      let x = 8 * quadrant.coefficient.x;
+      let y = 8 * quadrant.coefficient.y;
+      let textAnchor = quadrant.coefficient.x > 0 ? 'start' : 'end';
+      let considerHeight = quadrant.coefficient.y > 0 ? 0 : 0.5;
 
-      labels.push(
-        <text key={uuid.v1()}
-          className={`Labels-character Labels-${quadrant.name}`}
-          x={x}
-          y={y}
-          dx={paddingX}
-          dy={paddingY}
-          fontSize={FONT_SIZE}
-          textAnchor={leftAligned}>
-          {quadrant.name}
-        </text>
-      );
+      labels.push(<text key={uuid.v1()} className={`Labels-character Labels-${quadrant.name}`} x={x * gridUnit} y={-y * gridUnit + considerHeight * LABEL_HEIGHT} textAnchor={textAnchor}>{quadrant.name}</text>)
 
-      x = (CONTEXT_LABEL_POSITION - CONTEXT_LABEL_OFFSET) * quadrant.coefficient.x * scaleFactor;
-      y = - (CONTEXT_LABEL_POSITION + CONTEXT_LABEL_OFFSET) * quadrant.coefficient.y * scaleFactor;
-      paddingY = quadrant.coefficient.y > 0 ? 0 : LABEL_HEIGHT / 2;
-      labels.push(
-        <text key={uuid.v1()}
-          filter="url(#solid)"
-          className={`Labels-context Labels-${quadrant.labels[0]}`}
-          x={x}
-          y={y}
-          dx={0}
-          dy={paddingY}
-          fontSize={FONT_SIZE}
-          textAnchor={rightAligned}>
-          {quadrant.labels[0]}
-        </text>
-      );
+      x = 4.5 * quadrant.coefficient.x;
+      y = 5.5 * quadrant.coefficient.y;
+      textAnchor = quadrant.coefficient.x > 0 ? 'end' : 'start';
+      considerHeight = quadrant.coefficient.y > 0 ? 0 : 0.5;
+      labels.push(<text key={uuid.v1()} filter="url(#solid)" className={`Labels-context Labels-${quadrant.labels[0]}`} x={x * gridUnit} y={-y * gridUnit + considerHeight * LABEL_HEIGHT} textAnchor={textAnchor}>{quadrant.labels[0]}</text>)
 
-      x = (CONTEXT_LABEL_POSITION + CONTEXT_LABEL_OFFSET) * quadrant.coefficient.x * scaleFactor;
-      y = - (CONTEXT_LABEL_POSITION - CONTEXT_LABEL_OFFSET) * quadrant.coefficient.y * scaleFactor;
-      paddingY = quadrant.coefficient.y > 0 ? LABEL_HEIGHT / 2 : 0;
-      labels.push(
-        <text key={uuid.v1()}
-          filter="url(#solid)"
-          className={`Labels-context Labels-${quadrant.labels[1]}`}
-          x={x}
-          y={y}
-          dx={0}
-          dy={paddingY}
-          fontSize={FONT_SIZE}
-          textAnchor={leftAligned}>
-          {quadrant.labels[1]}
-        </text>
-      );
+      x = 5.5 * quadrant.coefficient.x;
+      y = 4.5 * quadrant.coefficient.y;
+      textAnchor = quadrant.coefficient.x > 0 ? 'start' : 'end';
+      considerHeight = quadrant.coefficient.y > 0 ? 0.5 : 0;
+      labels.push(<text key={uuid.v1()} filter="url(#solid)" className={`Labels-context Labels-${quadrant.labels[1]}`} x={x * gridUnit} y={-y * gridUnit + considerHeight * LABEL_HEIGHT} textAnchor={textAnchor}>{quadrant.labels[1]}</text>)
 
-      x = CORE_LABEL_POSITION * quadrant.coefficient.x * scaleFactor;
-      y = - CORE_LABEL_POSITION * quadrant.coefficient.y * scaleFactor;
-      const middlePaddingFactor = 4;
-      paddingY = LABEL_HEIGHT / middlePaddingFactor;
-      labels.push(
-        <text key={uuid.v1()}
-          className={`Labels-core Labels-${quadrant.labels[2]}`}
-          x={x}
-          y={y}
-          dx={0}
-          dy={paddingY}
-          fontSize={FONT_SIZE}
-          textAnchor='middle'>
-          {quadrant.labels[2]}
-        </text>
-      );
+      x = 2.5 * quadrant.coefficient.x;
+      y = 2.5 * quadrant.coefficient.y;
+      considerHeight = quadrant.coefficient.y > 0 ? 0 : 0.5;
+      textAnchor = 'middle';
+      labels.push(<text key={uuid.v1()} className={`Labels-core Labels-${quadrant.labels[2]}`} x={x * gridUnit} y={-y * gridUnit + considerHeight * LABEL_HEIGHT} textAnchor={textAnchor}>{quadrant.labels[2]}</text>)
 
     });
 
-    return (
-      <g id="Labels" className="Labels">
-        {labels}
-      </g>
-    );
+    let transform = 'translate(' + origin.x + ',' + origin.y + ')';
+    return <g id="Labels" className="Labels" transform={transform}>{labels}</g>;
   }
 
 }
 
 Labels.propTypes = {
-  scaleFactor: PropTypes.number.isRequired,
-};
-
-Labels.defaultProps = {
-  scaleFactor: 1,
+  origin: PropTypes.point.isRequired,
+  gridUnit: PropTypes.number.isRequired,
+  skin: PropTypes.shape({
+    dots: PropTypes.string.isRequired,
+  }).isRequired,
 };

--- a/src/components/Editor/Stage/Renderer/Lines.jsx
+++ b/src/components/Editor/Stage/Renderer/Lines.jsx
@@ -1,15 +1,13 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import uuid from 'node-uuid';
+import ForceFieldDescriptor from '../../../../ForceFieldDescriptor';
 import ForceFieldAnatomy from '../../../../ForceFieldAnatomy';
+import PropTypes from '../../../../PropTypes';
 
 import {allowCustomAttributes} from 'utils';
 import DOMProperty from 'react/lib/DOMProperty';
 
 allowCustomAttributes(DOMProperty, ['stroke-dasharray']);
-
-const DEFAULT_LINE_COLOR = '#000000';
-const LINE_WIDTH = 2;
-const DASHED_LINE_STROKE = 5;
 
 function P(x, y) {
   return {
@@ -21,147 +19,85 @@ function P(x, y) {
 class Line extends Component {
 
   render() {
-    const {scaleFactor, from, to, className, dashed, lineColor} = this.props;
-    if (dashed) {
-      return (
-        <line className={className}
-          stroke-dasharray={`${DASHED_LINE_STROKE}, ${DASHED_LINE_STROKE}`}
-          stroke={lineColor} strokeWidth={LINE_WIDTH}
-          x1={from.x * scaleFactor}
-          y1={-from.y * scaleFactor}
-          x2={to.x * scaleFactor}
-          y2={-to.y * scaleFactor} />
-        );
+    const {from, to, gridUnit, className, dashed} = this.props;
+    if(dashed) {
+      return <line className={className} stroke-dasharray="5, 5" stroke={'black'}  strokeWidth={2} x1={from.x * gridUnit} y1={-from.y * gridUnit} x2={to.x * gridUnit} y2={-to.y * gridUnit} />
     } else {
-      return (
-        <line className={className}
-          stroke={lineColor} strokeWidth={LINE_WIDTH}
-          x1={from.x * scaleFactor}
-          y1={-from.y * scaleFactor}
-          x2={to.x * scaleFactor}
-          y2={-to.y * scaleFactor} />
-        );
+      return <line className={className} stroke={'black'} strokeWidth={2} x1={from.x * gridUnit} y1={-from.y * gridUnit} x2={to.x * gridUnit} y2={-to.y * gridUnit} />
     }
   }
 }
 
 Line.propTypes = {
-  scaleFactor: PropTypes.number,
-  from: PropTypes.object,
-  to: PropTypes.object,
-  dashed: PropTypes.bool,
-  className: PropTypes.string,
-  lineColor: PropTypes.string,
-};
-
-Line.defaultProps = {
-  scaleFactor: 1,
-  dashed: false,
-  lineColor: DEFAULT_LINE_COLOR,
+  gridUnit: React.PropTypes.number,
+  from: React.PropTypes.object,
+  to: React.PropTypes.object,
+  dashed: React.PropTypes.bool,
+  className: React.PropTypes.string
 };
 
 export class Lines extends Component {
 
   render() {
-    const {
-      scaleFactor, lineColor,
-      coreWidth, contextWidth, centerCircleRadius, contextMarkerSize,
-    } = this.props;
-    const scaledCoreWidth = coreWidth * scaleFactor;
+    const {origin, gridUnit} = this.props;
 
-    const lines = ForceFieldAnatomy.QUADRANTS.map((quadrant) => {
-      const lines = [];
+    let lines = [];
+    lines.push(<Line key={'core-1'} className='Lines-core' from={P(-5, 5)} to={P(5, 5)} gridUnit={gridUnit} />);
+    lines.push(<Line key={'core-2'} className='Lines-core' from={P(5, 5)} to={P(5, -5)} gridUnit={gridUnit} />);
+    lines.push(<Line key={'core-3'} className='Lines-core' from={P(5, -5)} to={P(-5, -5)} gridUnit={gridUnit} />);
+    lines.push(<Line key={'core-4'} className='Lines-core' from={P(-5, -5)} to={P(-5, 5)} gridUnit={gridUnit} />);
 
-      let x1 = 0;
-      let y1 = centerCircleRadius * quadrant.coefficient.y;
-      let x2 = 0;
-      let y2 = coreWidth * quadrant.coefficient.y;
+    ForceFieldAnatomy.QUADRANTS.forEach((quadrant) => {
+
+      let x1 = 0 * quadrant.coefficient.x;
+      let y1 = ForceFieldAnatomy.CENTER_RADIUS * quadrant.coefficient.y;
+      let x2 = 0 * quadrant.coefficient.x;
+      let y2 = 5 * quadrant.coefficient.y;
       let key = `${quadrant.deg}-1`;
 
-      lines.push(
-        <Line key={key} className='Lines-core'
-          from={P(x1, y1)} to={P(x2, y2)} lineColor={lineColor}
-          scaleFactor={scaleFactor} />
-      );
+      lines.push(<Line key={key} className='Lines-core' from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
 
-      x1 = centerCircleRadius * quadrant.coefficient.x;
-      y1 = 0;
-      x2 = coreWidth * quadrant.coefficient.x;
-      y2 = 0;
+      x1 = ForceFieldAnatomy.CENTER_RADIUS * quadrant.coefficient.x;
+      y1 = 0 * quadrant.coefficient.y;
+      x2 = 5 * quadrant.coefficient.x;
+      y2 = 0 * quadrant.coefficient.y;
       key = `${quadrant.deg}-2`;
 
-      lines.push(
-        <Line key={key} className='Lines-core'
-          from={P(x1, y1)} to={P(x2, y2)} lineColor={lineColor}
-          scaleFactor={scaleFactor} />
-      );
+      lines.push(<Line key={key} className='Lines-core' from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
 
       // dashed
-      x1 = 0;
-      y1 = coreWidth * quadrant.coefficient.y;
-      x2 = 0;
-      y2 = (contextWidth + contextMarkerSize) * quadrant.coefficient.y;
+      x1 = 0 * quadrant.coefficient.x;
+      y1 = 5 * quadrant.coefficient.y;
+      x2 = 0 * quadrant.coefficient.x;
+      y2 = 8.5 * quadrant.coefficient.y;
       key = `${quadrant.deg}-3`;
 
-      lines.push(
-        <Line key={key} className='Lines-context' dashed={true}
-          from={P(x1, y1)} to={P(x2, y2)} lineColor={lineColor}
-          scaleFactor={scaleFactor} />
-      );
+      lines.push(<Line key={key} className='Lines-context' dashed={true} from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
 
-      x1 = coreWidth * quadrant.coefficient.x;
-      y1 = 0;
-      x2 = (contextWidth + contextMarkerSize) * quadrant.coefficient.x;
-      y2 = 0;
+      x1 = 5 * quadrant.coefficient.x;
+      y1 = 0 * quadrant.coefficient.y;
+      x2 = 8.5 * quadrant.coefficient.x;
+      y2 = 0 * quadrant.coefficient.y;
       key = `${quadrant.deg}-4`;
 
-      lines.push(
-        <Line key={key} className='Lines-context' dashed={true}
-          from={P(x1, y1)} to={P(x2, y2)} lineColor={lineColor}
-          scaleFactor={scaleFactor} />
-      );
+      lines.push(<Line key={key} className='Lines-context' dashed={true} from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
 
-      x1 = coreWidth * quadrant.coefficient.x;
-      y1 = coreWidth * quadrant.coefficient.y;
-      x2 = contextWidth * quadrant.coefficient.x;
-      y2 = contextWidth * quadrant.coefficient.y;
+      x1 = 5 * quadrant.coefficient.x;
+      y1 = 5 * quadrant.coefficient.y;
+      x2 = 8 * quadrant.coefficient.x;
+      y2 = 8 * quadrant.coefficient.y;
       key = `${quadrant.deg}-5`;
 
-      lines.push(
-        <Line key={key} className='Lines-context'
-          from={P(x1, y1)} to={P(x2, y2)} lineColor={lineColor}
-          scaleFactor={scaleFactor} />
-      );
-      return lines;
+      lines.push(<Line key={key} className='Lines-context' from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
     });
 
-    return (
-      <g id="Lines" className="Lines">
-        <rect className='Lines-core'
-          x={-scaledCoreWidth} y={-scaledCoreWidth}
-          width={scaledCoreWidth * 2} height={scaledCoreWidth * 2}
-          fill='none' strokeWidth={LINE_WIDTH} stroke={lineColor}/>
-        {lines}
-      </g>
-    );
+    const transform = `translate(${origin.x},${origin.y})`;
+    return <g id="Lines" className="Lines" transform={transform}>{lines}</g>;
   }
 
 }
 
 Lines.propTypes = {
-  scaleFactor: PropTypes.number,
-  contextWidth: PropTypes.number,
-  coreWidth: PropTypes.number,
-  centerCircleRadius: PropTypes.number,
-  contextMarkerSize: PropTypes.number,
-  lineColor: PropTypes.string,
-};
-
-Lines.defaultProps = {
-  scaleFactor: 1,
-  contextWidth: 8,
-  coreWidth: 5,
-  centerCircleRadius: Math.sqrt(2),
-  contextMarkerSize: 0.5,
-  lineColor: DEFAULT_LINE_COLOR,
+  origin: PropTypes.point.isRequired,
+  gridUnit: PropTypes.number.isRequired,
 };

--- a/src/components/Editor/Stage/Renderer/Lines.jsx.orig
+++ b/src/components/Editor/Stage/Renderer/Lines.jsx.orig
@@ -1,0 +1,172 @@
+<<<<<<< 84659fd7e2899bc867d8c474f3ae1725589c41fe:src/components/Editor/Stage/Renderer/Lines.jsx
+import React, {Component, PropTypes} from 'react';
+import uuid from 'node-uuid';
+import ForceFieldDescriptor from '../../../../ForceFieldDescriptor';
+import ForceFieldAnatomy from '../../../../ForceFieldAnatomy';
+=======
+import React, {Component} from 'react';
+import PropTypes from 'PropTypes';
+import ForceFieldDescriptor from 'ForceFieldDescriptor';
+import Anatomy from 'ForceFieldAnatomy';
+
+import {allowCustomAttributes} from 'utils';
+>>>>>>> add utils, refactoring lines:src/components/Editor/ForceField/Renderer/Lines.jsx
+import DOMProperty from 'react/lib/DOMProperty';
+
+allowCustomAttributes(DOMProperty, ['stroke-dasharray']);
+
+<<<<<<< 84659fd7e2899bc867d8c474f3ae1725589c41fe:src/components/Editor/Stage/Renderer/Lines.jsx
+DOMProperty.injection.injectDOMPropertyConfig({
+  isCustomAttribute: function (attributeName) {
+    return (attributeName === 'stroke-dasharray');
+  }
+});
+=======
+class Line extends Component {
+
+  render() {
+    const from = this.props.from;
+    const to = this.props.to;
+    const GU = this.props.gridUnit;
+    const className = this.props.className;
+    if(this.props.dashed) {
+      return <line className={className} stroke-dasharray="5, 5" stroke={'black'} strokeWidth={2} x1={from.x * GU} y1={-from.y * GU} x2={to.x * GU} y2={-to.y * GU} />;
+    } else {
+      return <line className={className} stroke={'black'} strokeWidth={2} x1={from.x * GU} y1={-from.y * GU} x2={to.x * GU} y2={-to.y * GU} />;
+    }
+    
+  }
+}
+
+Line.propTypes = {
+  gridUnit: PropTypes.number.isRequired,
+  from: PropTypes.point.isRequired,
+  to: PropTypes.point.isRequired,
+  dashed: PropTypes.bool,
+  className: PropTypes.string,
+};
+>>>>>>> add utils, refactoring lines:src/components/Editor/ForceField/Renderer/Lines.jsx
+
+function P(x, y) {
+  return {
+    x: x,
+    y: y,
+  };
+}
+
+<<<<<<< 84659fd7e2899bc867d8c474f3ae1725589c41fe:src/components/Editor/Stage/Renderer/Lines.jsx
+class Line extends Component {
+
+  render() {
+    const {from, to, gridUnit, className, dashed} = this.props;
+=======
+export default class Lines extends Component {
+>>>>>>> add utils, refactoring lines:src/components/Editor/ForceField/Renderer/Lines.jsx
+
+    if(dashed) {
+      return <line className={className} stroke-dasharray="5, 5" stroke={'black'}  strokeWidth={2} x1={from.x * gridUnit} y1={-from.y * gridUnit} x2={to.x * gridUnit} y2={-to.y * gridUnit} />
+    } else {
+      return <line className={className} stroke={'black'} strokeWidth={2} x1={from.x * gridUnit} y1={-from.y * gridUnit} x2={to.x * gridUnit} y2={-to.y * gridUnit} />
+    }
+  }
+}
+
+<<<<<<< 84659fd7e2899bc867d8c474f3ae1725589c41fe:src/components/Editor/Stage/Renderer/Lines.jsx
+Line.propTypes = {
+  gridUnit: React.PropTypes.number,
+  from: React.PropTypes.object,
+  to: React.PropTypes.object,
+  dashed: React.PropTypes.bool,
+  className: React.PropTypes.string
+};
+
+export class Lines extends Component {
+
+  render() {
+    const {stageWidth, stageHeight, gridUnit} = this.props;
+    const origin = {x: Math.floor(stageWidth / 2), y: Math.floor(stageHeight / 2)};
+
+    let lines = [];
+    lines.push(<Line key={'core-1'} className='Lines-core' from={P(-5, 5)} to={P(5, 5)} gridUnit={gridUnit} />);
+    lines.push(<Line key={'core-2'} className='Lines-core' from={P(5, 5)} to={P(5, -5)} gridUnit={gridUnit} />);
+    lines.push(<Line key={'core-3'} className='Lines-core' from={P(5, -5)} to={P(-5, -5)} gridUnit={gridUnit} />);
+    lines.push(<Line key={'core-4'} className='Lines-core' from={P(-5, -5)} to={P(-5, 5)} gridUnit={gridUnit} />);
+=======
+  render() {
+    /*eslint no-magic-numbers:0*/
+
+    const GU = this.props.gridUnit;
+    const origin = this.props.origin;
+    const dotsColor = this.props.skin.dots;
+
+    const lines = [];
+    lines.push(<Line key={'core-1'} className='Lines-core' from={P(-5, 5)} to={P(5, 5)} gridUnit={GU} />);
+    lines.push(<Line key={'core-2'} className='Lines-core' from={P(5, 5)} to={P(5, -5)} gridUnit={GU} />);
+    lines.push(<Line key={'core-3'} className='Lines-core' from={P(5, -5)} to={P(-5, -5)} gridUnit={GU} />);
+    lines.push(<Line key={'core-4'} className='Lines-core' from={P(-5, -5)} to={P(-5, 5)} gridUnit={GU} />);
+>>>>>>> add utils, refactoring lines:src/components/Editor/ForceField/Renderer/Lines.jsx
+
+    Anatomy.QUADRANTS.forEach((quadrant) => {
+
+      let x1 = 0 * quadrant.coefficient.x;
+      let y1 = Anatomy.CENTER_RADIUS * quadrant.coefficient.y;
+      let x2 = 0 * quadrant.coefficient.x;
+      let y2 = 5 * quadrant.coefficient.y;
+      let key = `${quadrant.deg}-1`;
+
+      lines.push(<Line key={key} className='Lines-core' from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
+
+      x1 = Anatomy.CENTER_RADIUS * quadrant.coefficient.x;
+      y1 = 0 * quadrant.coefficient.y;
+      x2 = 5 * quadrant.coefficient.x;
+      y2 = 0 * quadrant.coefficient.y;
+      key = `${quadrant.deg}-2`;
+
+      lines.push(<Line key={key} className='Lines-core' from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
+
+      // dashed
+      x1 = 0 * quadrant.coefficient.x;
+      y1 = 5 * quadrant.coefficient.y;
+      x2 = 0 * quadrant.coefficient.x;
+      y2 = 8.5 * quadrant.coefficient.y;
+      key = `${quadrant.deg}-3`;
+
+      lines.push(<Line key={key} className='Lines-context' dashed={true} from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
+
+      x1 = 5 * quadrant.coefficient.x;
+      y1 = 0 * quadrant.coefficient.y;
+      x2 = 8.5 * quadrant.coefficient.x;
+      y2 = 0 * quadrant.coefficient.y;
+      key = `${quadrant.deg}-4`;
+
+      lines.push(<Line key={key} className='Lines-context' dashed={true} from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
+
+      x1 = 5 * quadrant.coefficient.x;
+      y1 = 5 * quadrant.coefficient.y;
+      x2 = 8 * quadrant.coefficient.x;
+      y2 = 8 * quadrant.coefficient.y;
+      key = `${quadrant.deg}-5`;
+
+      lines.push(<Line key={key} className='Lines-context' from={P(x1, y1)} to={P(x2, y2)} gridUnit={gridUnit} />);
+
+<<<<<<< 84659fd7e2899bc867d8c474f3ae1725589c41fe:src/components/Editor/Stage/Renderer/Lines.jsx
+      //lines.push(<text className="Labels-character" x={x * gridUnit} y={-y * gridUnit + considerHeight * LABEL_HEIGHT} textAnchor={textAnchor}>{quadrant.name}</text>)
+
+=======
+>>>>>>> add utils, refactoring lines:src/components/Editor/ForceField/Renderer/Lines.jsx
+    });
+
+    const transform = `translate(${origin.x},${origin.y})`;
+    return <g id="Lines" className="Lines" transform={transform}>{lines}</g>;
+  }
+
+}
+<<<<<<< 84659fd7e2899bc867d8c474f3ae1725589c41fe:src/components/Editor/Stage/Renderer/Lines.jsx
+
+Lines.propTypes = {
+  stageWidth: PropTypes.number.isRequired,
+  stageHeight: PropTypes.number.isRequired,
+  gridUnit: PropTypes.number.isRequired,
+};
+=======
+>>>>>>> add utils, refactoring lines:src/components/Editor/ForceField/Renderer/Lines.jsx

--- a/src/components/Editor/Stage/Renderer/Marker.jsx
+++ b/src/components/Editor/Stage/Renderer/Marker.jsx
@@ -1,88 +1,58 @@
 import React, {Component} from 'react';
-import Vector from 'victor';
 import PropTypes from '../../../../PropTypes';
 import ForceFieldAnatomy from '../../../../ForceFieldAnatomy';
-
-const CONTEXT_MARKER_WIDTH = 3;
-const CORE_EDGE_MARKER_WIDTH = 6;
-const CENTER_MARKER_WIDTH = 6;
 
 export class Marker extends Component {
 
   render() {
-    const {
-      scaleFactor,
-      contextWidth, coreWidth, centerCircleRadius, contextMarkerSize,
-      skin: {marker},
-    } = this.props;
+    const {origin, gridUnit, skin: {marker}} = this.props;
+    const circleRadius = ForceFieldAnatomy.CENTER_RADIUS;
 
     const characterMarkerCoordinates = [
-      new Vector(
-        contextWidth + contextMarkerSize,
-        -contextWidth,
-      ),
-      new Vector(
-        contextWidth,
-        -contextWidth,
-      ),
-      new Vector(
-        contextWidth,
-        -contextWidth - contextMarkerSize,
-      ),
-    ].map((point) => {
-      point.multiplyScalar(scaleFactor);
-      return `${point.x},${point.y}`;
-    }).join(' ');
+      8 * gridUnit + 1/2 * gridUnit,
+      -8 * gridUnit,
+      8 * gridUnit,
+      -8 * gridUnit,
+      8 * gridUnit,
+      -8 * gridUnit - 1/2 * gridUnit
+    ].join()
 
-    const groups = [];
+    let groups = [];
 
-    const coreRectEdge = coreWidth * scaleFactor;
+    const gu5 = 5 * gridUnit;
 
-    ForceFieldAnatomy.QUADRANTS.forEach((quadrant) => {
+    ForceFieldAnatomy.QUADRANTS.forEach(function(quadrant) {
 
       const deg = quadrant.deg;
       const transform = `rotate(${deg})`;
 
       groups.push(
         <g key={deg} transform={transform}>
-          <polyline points={characterMarkerCoordinates}
-            strokeWidth={CONTEXT_MARKER_WIDTH} fill='none' stroke={marker} />
-          <circle r={(1 / CORE_EDGE_MARKER_WIDTH) * scaleFactor}
-            cx={coreRectEdge} cy={-coreRectEdge} fill={marker} />
+          <polyline points={characterMarkerCoordinates} strokeWidth='3' fill='none' stroke={marker} />
+          <circle r={6} cx={gu5} cy={-gu5} fill={marker} />
         </g>
       );
 
     });
 
     groups.push(
-      <circle key={'circle'}
-        cx={0} cy={0} r={centerCircleRadius * scaleFactor}
-        fill='none' strokeWidth={CENTER_MARKER_WIDTH} stroke={marker} />
-    );
+      <circle key={'circle'} cx={0} cy={0} r={circleRadius * gridUnit} fill='none' strokeWidth='3' stroke={marker} />
+    )
 
-    return (
-      <g id="Marker" className="Marker">
-        {groups}
-      </g>
-    );
+    let transform = 'translate(' + origin.x + ',' + origin.y + ')';
+    return <g id="Marker" className="Marker" transform={transform}>{groups}</g>;
   }
 }
 
 Marker.propTypes = {
-  scaleFactor: PropTypes.number.isRequired,
-  contextWidth: PropTypes.number,
-  coreWidth: PropTypes.number,
-  centerCircleRadius: PropTypes.number,
-  contextMarkerSize: PropTypes.number,
+  origin: PropTypes.point.isRequired,
+  gridUnit: PropTypes.number.isRequired,
   skin: PropTypes.shape({
     marker: PropTypes.string.isRequired,
   }).isRequired,
+  style: PropTypes.object,
 };
 
 Marker.defaultProps = {
-  scaleFactor: 1,
-  contextWidth: 8,
-  coreWidth: 5,
-  centerCircleRadius: Math.sqrt(2),
-  contextMarkerSize: 0.5,
+  style: {},
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,14 +7,13 @@ import {ConnectedEditor} from './state/components/ConnectedEditor';
 import reducer, {observeEnergies} from './state/reducer';
 import {setState} from './state/action_creators';
 import * as actionCreators from './state/action_creators';
-import styles from './styles/main.css';
 
 const finalCreateStore = compose(
   window.devToolsExtension ? window.devToolsExtension() : (f) => f,
 )(createStore);
 const store = finalCreateStore(reducer);
 
-const initialState = fromJS({energies: [
+var initialState = fromJS({energies: [
   {id: uuid.v1(), x: -1, y: -1, strength: 10, isMuted: false},
   {id: uuid.v1(), x: 1, y: 1, strength: -10, isMuted: false},
   {id: uuid.v1(), x: -1, y: 1, strength: -10, isMuted: false},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,10 +29,7 @@ module.exports = [
       loaders: [{
         test: /\.jsx?$/,
         exclude: /node_modules/,
-        loaders: [
-          'react-hot',
-          'babel?presets[]=react,presets[]=es2015,plugins[]=syntax-trailing-function-commas'
-        ]
+        loader: 'react-hot!babel'
       },{
         test: /\.css$/,
         exclude: /node_modules/,
@@ -72,11 +69,7 @@ module.exports = [
       loaders: [{
         test: /\.jsx?$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['react', 'es2015'],
-          plugins: ['syntax-trailing-function-commas']
-        }
+        loader: 'babel-loader'
       }]
     },
     resolve: {


### PR DESCRIPTION
Reverts preciousforever/productfield#5

the refactoring introduces some good parts, especially using viewBox + origin instead of transform in every component of renderer.

but the introduction of scaleFactor messes things up and make sthe drawing code harder to read.
scaleFactor is something different than gridUnit. the visual anatomy of the productfield is based on grind-units. the concept of grid units should stay visible in the code.

when refactoring for the illustration server, please visually verify the consequences right here: http://localhost:8080/illustrator.html
